### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/harveythompson0/5f58a5a6-10ee-44d3-96fb-d566d3c56fd7/783f0503-5fa7-4205-8c92-d87e6995adce/_apis/work/boardbadge/a73fd51e-ce49-47e7-9869-88009e9b203e)](https://dev.azure.com/harveythompson0/5f58a5a6-10ee-44d3-96fb-d566d3c56fd7/_boards/board/t/783f0503-5fa7-4205-8c92-d87e6995adce/Microsoft.RequirementCategory)
 # Test
 This is a test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/harveythompson0/5f58a5a6-10ee-44d3-96fb-d566d3c56fd7/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.